### PR TITLE
typo: add line break above table

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ Refer to [Configuration](#configuration) for the various extension settings deta
 
 # Commands
 This extension adds the following commands to VSCode:
+
 | Command name | Keyboard Shortcut | Description |
 |---|---|---|
 | Header Insert | ctrl-alt-H ctrl-alt-H | Inserts a new file header |


### PR DESCRIPTION
Minor change to make table render on Visual Studio Code extension details.

![image](https://user-images.githubusercontent.com/22801583/131234743-2745be32-90f5-4de6-adbe-1c0d2c61a008.png)
