### PR TITLE
pass document instead of editor to getVariables()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,10 @@ All notable changes to the "psi-header" extension will be documented in this fil
 
 Report bugs, issues, suggestions at https://github.com/davidquinn/psi-header
 
-## Unreleased
+## 1.19.0 (30 April 2022)
+*__FIX__*: Fixed an issue where information for the wrong file could be applied to the header when saving a file that was not the active document. Relates to [Issue 21](https://github.com/davidquinn/psi-header/issues/21).
+
+## 1.18.0 (07 March 2022)
 *__NEW__*: Added `"spacesBetweenYears"` config option.
 
 ## 1.17.0 (12 January 2022)

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"displayName": "psioniq File Header",
 	"description": "Configurable file header and changes tracking.",
 	"icon": "img/psi-logo.png",
-	"version": "1.17.0",
+	"version": "1.19.0",
 	"publisher": "psioniq",
 	"license": "SEE LICENSE IN LICENSE.txt",
 	"bugs": {

--- a/src/changesTrackingController.ts
+++ b/src/changesTrackingController.ts
@@ -128,7 +128,7 @@ export class ChangesTrackingController {
 				if (this._config.enforceHeader && this._docNeedsHeader(doc)) {
 					insertFileHeader();
 				}
-				const variables: IVariableList = getVariables(this._wsConfig, activeTextEditor, mainConfig, langConfig, !this._config.updateLicenseVariables);
+				const variables: IVariableList = getVariables(this._wsConfig, doc, mainConfig, langConfig, !this._config.updateLicenseVariables);
 				const template: Array<string> = getTemplateConfig(this._wsConfig, doc.languageId, doc.fileName).template;
 
 				const modDate: string = langConfig.modDate || this._config.modDate;
@@ -175,6 +175,13 @@ export class ChangesTrackingController {
 								// we have come to the first comment block in the file, so start searching
 								inComment = true;
 							}
+							
+							// FIXME: The file being saved may not be the same file as active editor.
+							// This should be doc.tabSize, but there currently is no API to get this.
+							// So we just hope that the file being saved has the same tab size as the
+							// active editor and fall back to 4 as a default if there is no active editor.
+							const tabSize = activeTextEditor ? <number> activeTextEditor.options.tabSize : 4;
+
 							if (inComment || lastCommentLine) {
 								if (this._startsWith(txt, langConfig.prefix, modAuthor)) {
 									replacers.push({
@@ -185,7 +192,7 @@ export class ChangesTrackingController {
 												: modAuthorWithPrefix + (modAuthorWithPrefix.endsWith(' ') ? '' : ' ') + this._author,
 											langConfig.suffix,
 											langConfig.lineLength,
-											<number> activeTextEditor.options.tabSize
+											tabSize
 										)
 									});
 								}
@@ -198,7 +205,7 @@ export class ChangesTrackingController {
 												: modDateWithPrefix + (modDateWithPrefix.endsWith(' ') ? '' : ' ') + date,
 											langConfig.suffix,
 											langConfig.lineLength,
-											<number> activeTextEditor.options.tabSize
+											tabSize
 										)
 									});
 								} else if (replaceList && replaceList.length > 0) {
@@ -215,7 +222,7 @@ export class ChangesTrackingController {
 														replacePlaceholders(modReplaceTemplate, variables, txt, mainConfig.creationDateZero),
 														langConfig.suffix,
 														langConfig.lineLength,
-														<number> activeTextEditor.options.tabSize
+														tabSize
 													)
 												});
 											}

--- a/src/helper.ts
+++ b/src/helper.ts
@@ -34,7 +34,8 @@ import {
 	workspace,
 	window,
 	TextEditor,
-	WorkspaceConfiguration
+	WorkspaceConfiguration,
+	TextDocument
 } from 'vscode';
 import * as k_ from './constants';
 import {
@@ -295,11 +296,11 @@ function mapProperty(source: Object, target: Object, key: string): void {
  * @param {boolean} ignoreLicense
  * @returns {IVariableList}
  */
-export function getVariables(wsConfig: WorkspaceConfiguration, editor: TextEditor, config: IConfig, langConfig: ILangConfig, ignoreLicense: boolean = false): IVariableList {
+export function getVariables(wsConfig: WorkspaceConfiguration, document: TextDocument, config: IConfig, langConfig: ILangConfig, ignoreLicense: boolean = false): IVariableList {
 	let variables: IVariableList = [];
 	const now: Date = new Date();
 	const fcreated: Date = getActiveFileCreationDate(config.creationDateZero) || new Date();
-	const currentFile: string = editor.document.fileName;
+	const currentFile: string = document.fileName;
 	// system variables
 	variables.push([k_.VAR_DATE, now.toDateString()]);
 	variables.push([k_.VAR_TIME, now.toLocaleTimeString()]);

--- a/src/insertChangeLogCommand.ts
+++ b/src/insertChangeLogCommand.ts
@@ -62,7 +62,7 @@ export function insertChangeLog() {
 
 	const tpl: Array<string> = templateConfig.changeLogEntryTemplate || k_.CHANGE_LOG_ENTRY_TEMPLATE;
 	const config: helper.IConfig = helper.getConfig(wsConfig, langConfig);
-	const variables: helper.IVariableList = helper.getVariables(wsConfig, editor, config, langConfig);
+	const variables: helper.IVariableList = helper.getVariables(wsConfig, editor.document, config, langConfig);
 	const mergedChangeLog: Array<string> = helper.replaceTemplateVariables(tpl, langConfig.prefix, variables, config.creationDateZero).split('\n');
 	const row: number = captionRow + (naturalOrder ? (-1 * (templateConfig.changeLogFooterLineCount || 0)) : (templateConfig.changeLogHeaderLineCount || 0));
 	const col: number =  editor.document.lineAt(row).text.length;

--- a/src/insertFileHeaderCommand.ts
+++ b/src/insertFileHeaderCommand.ts
@@ -49,7 +49,7 @@ export function insertFileHeader() {
 	const langConfig: ILangConfig = getLanguageConfig(wsConfig, editor.document.languageId, editor.document.fileName);
 	const template: Array<string> = getTemplateConfig(wsConfig, editor.document.languageId, editor.document.fileName).template;
 	const config: IConfig = getConfig(wsConfig, langConfig);
-	const variables: IVariableList = getVariables(wsConfig, editor, config, langConfig);
+	const variables: IVariableList = getVariables(wsConfig, editor.document, config, langConfig);
 
 	// console.log(`insertFileHeader into ${editor.document.fileName}`);
 


### PR DESCRIPTION
VS Code can save documents that are not the active editor (i.e. mass search/replace). Since the active editor was being used to determine the file info for replacements on save, files were getting updated with the wrong file info. This fixes the problem by passing the document object instead of the editor object to the getVariables() function. This way, the variable values are derived from the document being saved instead of the active editor.

Fixes #21