### PR TITLE
spdx-license-list: upgrade to 6.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -423,7 +423,7 @@
 		"fullname": "^4.0.1",
 		"minimatch": "^3.0.4",
 		"moment": "^2.24.0",
-		"spdx-license-list": "^3.0.1",
+		"spdx-license-list": "^6.6.0",
 		"username": "^3.0.0",
 		"wordwrap": "^1.0.0"
 	}


### PR DESCRIPTION
The spdx-license-list used is clearly outdated. I'm simply updating the dependency.