### PR TITLE
Fix pathsep override regex if is Windows

### DIFF
--- a/src/helper.ts
+++ b/src/helper.ts
@@ -1290,8 +1290,13 @@ export function trimStart(s: string) {
 	return s.replace(r, '');
 }
 
-function overrideSeparator(path: string, separator?: string): string {
-	return separator ? path.replace(/\//g, separator) : path;
+function overrideSeparator(path, separator) {
+    const isWin32 = process.platform === "win32";
+    const systemSeparator = isWin32 ? '\\' : '/';
+    if (separator === systemSeparator) {
+        return path;
+    }
+    return path.replace(new RegExp(escapeRegExp(systemSeparator), 'g'), separator);
 }
 
 export {BASE_SETTINGS} from './constants';

--- a/src/helper.ts
+++ b/src/helper.ts
@@ -1290,9 +1290,14 @@ export function trimStart(s: string) {
 	return s.replace(r, '');
 }
 
-function overrideSeparator(path, separator) {
+function overrideSeparator(path: string, separator?: string): string {
+	if (!separator) {
+		return path;
+	}
+	// if isWin32, then the system separator is '\', otherwise it is '/'.
     const isWin32 = process.platform === "win32";
     const systemSeparator = isWin32 ? '\\' : '/';
+
     if (separator === systemSeparator) {
         return path;
     }


### PR DESCRIPTION
Fix the issue that "overrideSeparator" has no effect on Windows platform